### PR TITLE
ProgressBar improvements

### DIFF
--- a/f3_launcher.cpp
+++ b/f3_launcher.cpp
@@ -185,7 +185,7 @@ f3_launcher::f3_launcher()
             SIGNAL(timeout()),
             this,
             SLOT(on_timer_timeout()));
-    timer.setInterval(1500);
+    timer.setInterval(200);
 
 }
 
@@ -229,7 +229,7 @@ void f3_launcher::startCheck(QString devPath)
         stopCheck();
 
     f3_cui_output.clear();
-    progress = 0;
+    progress10K = 0;
     status = f3_launcher_running;
     emit f3_launcher_status_changed(f3_launcher_running);
 
@@ -517,7 +517,7 @@ void f3_launcher::on_f3_cui_finished()
         }
 
         stage = 2;
-        progress = 0;
+        progress10K = 0;
         QStringList args;
         if (showProgress)
             args << QString(F3_OPTION_SHOW_PROGRESS);
@@ -560,9 +560,9 @@ void f3_launcher::on_timer_timeout()
     if (p >= 0)
     {
         int p2 = temp.indexOf("... ", p - 7);
-        int percentage = temp.mid(p2 + 4, p - p2 - 4).trimmed().toFloat();
-        if (percentage > progress)
-            progress = percentage;
+        float percentage10K = temp.mid(p2 + 4, p - p2 - 4).trimmed().toFloat() * 100.0f;
+        if (percentage10K > progress10K)
+            progress10K = percentage10K;
         emit f3_launcher_status_changed(f3_launcher_progressed);
     }
     f3_cui_output.append(temp);

--- a/f3_launcher.h
+++ b/f3_launcher.h
@@ -66,7 +66,7 @@ public:
     QString getOption(QString key);
     void startFix();
     QString f3_cui_output;
-    int progress;
+    int progress10K;
 
 signals:
     void f3_launcher_status_changed(f3_launcher_status status);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -168,6 +168,8 @@ void MainWindow::promptFix()
 
 void MainWindow::on_cui_status_changed(f3_launcher_status status)
 {
+    char chSpin = ui->labelProgressSpin->text().data()[0].toAscii();
+    QString qsSpinNext;
     switch(status)
     {
         case f3_launcher_ready:
@@ -208,14 +210,15 @@ void MainWindow::on_cui_status_changed(f3_launcher_status status)
                                     .append(report.WritingSpeed)
                                     );
             ui->frameResult->show();
-            ui->progressBar->setMaximum(100);
+            ui->progressBar->setMaximum(10000);
             showCapacity(report.availability * 100);
             break;
         }
         case f3_launcher_stopped:
             showStatus("Stopped.");
-            ui->progressBar->setMaximum(100);
+            ui->progressBar->setMaximum(10000);
             ui->progressBar->setValue(0);
+            ui->labelProgressSpin->setText("!");
             break;
         case f3_launcher_staged:
         {
@@ -224,11 +227,20 @@ void MainWindow::on_cui_status_changed(f3_launcher_status status)
             ui->labelProgress->setText(progressText);
             ui->progressBar->setMaximum(0);
             ui->progressBar->setValue(0);
+            ui->labelProgressSpin->setText("?");
             break;
         }
         case f3_launcher_progressed:
-            ui->progressBar->setMaximum(100);
-            ui->progressBar->setValue(cui.progress);
+            ui->progressBar->setMaximum(10000);
+            ui->progressBar->setValue(cui.progress10K);
+            switch(chSpin){
+                case '|': qsSpinNext = "/"; break;
+                case '/': qsSpinNext = "---"; break;
+                case '-': qsSpinNext = "\\"; break;
+                case '\\': qsSpinNext = "|"; break;
+                default: qsSpinNext = "|"; break;
+            }
+            ui->labelProgressSpin->setText(qsSpinNext);
             break;
     }
     if (status == f3_launcher_running ||

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -439,7 +439,7 @@ QProgressBar::chunk {background-color: rgb(75, 226, 110); border-radius: 3px;}</
       <rect>
        <x>10</x>
        <y>10</y>
-       <width>331</width>
+       <width>291</width>
        <height>20</height>
       </rect>
      </property>
@@ -455,6 +455,28 @@ QProgressBar::chunk {background-color: rgb(75, 226, 110); border-radius: 3px;}</
        <width>321</width>
        <height>16</height>
       </rect>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="format">
+      <string>%v/%m (%p%)</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="labelProgressSpin">
+     <property name="geometry">
+      <rect>
+       <x>330</x>
+       <y>10</y>
+       <width>21</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>*</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
     </widget>
    </widget>


### PR DESCRIPTION
ProgressBar; show smaller increments, increase refresh speed, show update ticks.
When testing a large SD card, it takes 'a while' before the progressbar advances, and can also take a while for the test to fail, so you're not sure if test is actually advancing. The changes I propose address this by:
- decreasing step size from 1% to 0.01%, 
- show e.g. '1234/10000 (12%)' then '1256/10000 (12%)' rather than steady '12%' (GRR! why won't it handle decimals?), 
- show a rotating 'spinner' every update, 
- checking f3 output every 200mS instead of 1500mS. 
NB I am not a QT developer; there may be better ways to do what I did.